### PR TITLE
add: embed frame on `layout.tsx` for `wownar`

### DIFF
--- a/wownar/src/app/layout.tsx
+++ b/wownar/src/app/layout.tsx
@@ -19,6 +19,22 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        {/* Start of Neynar Frame */}
+        <title>Wownar</title>
+        <meta property="og:title" content="Wownar"/>
+        <meta property="og:description" content="A demo app (powered by Neynar) that will help user to cast" />
+        <meta property="og:image" content="https://i.imgur.com/WtMhBtP.png"/>
+        <meta property="fc:frame" content="vNext"/>
+        <meta property="fc:frame:image" content="https://i.imgur.com/WtMhBtP.png"/>
+        <meta property="fc:frame:image:aspect_ratio" content="1.91:1"/> 
+        <meta property="fc:frame:button:1" content="Repo"/>
+        <meta property="fc:frame:button:1:action" content="post_redirect"/>
+        <meta property="fc:frame:button:2" content="View Wownar"/>
+        <meta property="fc:frame:button:2:action" content="post_redirect"/>
+        <meta property="fc:frame:post_url" content="https://frames.neynar.com/f/e5b5f4b9/e8d1c50b"/>
+        {/* End of Neynar Frame */}
+      </head>
       <body className={inter.className}>
         <AppProvider>
           {children}


### PR DESCRIPTION
adds the meta tags for a Neynar frame([this frame](https://frames.neynar.com/f/e5b5f4b9/e8d1c50b) to `wownar` using the new meta tag export feature on Neynar Frame Studio as an example. the screenshot below shows what the frame looks like on Wownar, and the demo below shows how you add custom meta tags to a Next.js app like `wownar`

<img width="843" alt="Screenshot 2024-06-25 at 2 08 26 PM" src="https://github.com/neynarxyz/farcaster-examples/assets/12853808/cd63fb8b-a2f3-430e-ac09-d11b53133f5c">

https://github.com/neynarxyz/farcaster-examples/assets/12853808/c2d372e7-04ac-457f-a169-1f4e401aa735