### PR TITLE
Show SIWN deprecation banner on demo.neynar.com

### DIFF
--- a/wownar/src/app/Screens/layout.tsx
+++ b/wownar/src/app/Screens/layout.tsx
@@ -3,6 +3,7 @@
 import { ScreenState, useApp } from "@/Context/AppContext";
 import Button from "@/components/Button";
 import Signout from "@/components/icons/Signout";
+import SiwnDeprecationBanner from "@/components/SiwnDeprecationBanner";
 import useLocalStorage from "@/hooks/use-local-storage-state";
 import { UserInfo } from "@/types";
 import Image from "next/image";
@@ -44,14 +45,15 @@ const ScreenLayout = ({ children }: Props) => {
           </div>
         )}
       </header>
+      <SiwnDeprecationBanner />
       {children}
       <footer className="flex flex-col justify-center items-center gap-y-6 text-center p-4">
         <Link
-          href="https://docs.neynar.com/docs/how-to-let-users-connect-farcaster-accounts-with-write-access-for-free-using-sign-in-with-neynar-siwn"
+          href="https://docs.neynar.com/docs/integrate-managed-signers"
           target="_blank"
         >
-          Connect Farcaster accounts for free using&nbsp;
-          <span className="font-bold">Sign in with Neynar</span>
+          Connect Farcaster accounts using&nbsp;
+          <span className="font-bold">Neynar-managed signers</span>
         </Link>
         <Link
           href="https://github.com/neynarxyz/farcaster-examples/tree/main/wownar"

--- a/wownar/src/components/SiwnDeprecationBanner/index.tsx
+++ b/wownar/src/components/SiwnDeprecationBanner/index.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+// Date.UTC months are 0-indexed, so 7 = August.
+const isSiwnRetired = () => Date.now() >= Date.UTC(2026, 7, 14);
+
+const SiwnDeprecationBanner = () => {
+  const retired = isSiwnRetired();
+
+  return (
+    <div className="w-full bg-amber-500/15 border-b border-amber-400/40 text-amber-200 text-center text-sm px-4 py-2">
+      <span className="font-bold">
+        {retired
+          ? "Sign In With Neynar has been retired."
+          : "Sign In With Neynar is being retired on August 14, 2026."}
+      </span>{" "}
+      Use{" "}
+      <Link
+        href="https://docs.neynar.com/docs/integrate-managed-signers"
+        target="_blank"
+        className="underline"
+      >
+        Neynar-managed signers
+      </Link>{" "}
+      instead.
+    </div>
+  );
+};
+
+export default SiwnDeprecationBanner;


### PR DESCRIPTION
`wownar` is what's deployed at **demo.neynar.com**, and it's the Sign In With Neynar demo. SIWN is retired on **Friday, 14 August 2026**, and the demo currently gives visitors no indication of that.

## Banner

Adds `SiwnDeprecationBanner`, mounted in `src/app/Screens/layout.tsx` — the layout shared by both the Signin and Home screens, so one insertion covers the whole app.

The copy switches automatically at the cutoff (*"is being retired on August 14, 2026"* → *"has been retired"*), so it stays correct without a redeploy.

Styled for this app's hard-coded dark gradient (`bg-amber-500/15`, `border-amber-400/40`, `text-amber-200`) rather than the light-theme amber used on app.neynar.com. No `dark:` variants — `tailwind.config.ts` has no `darkMode` key; the app is simply always dark.

## Footer link fix

The footer linked to `docs.neynar.com/docs/how-to-let-users-connect-farcaster-accounts-with-write-access-for-free-using-sign-in-with-neynar-siwn`, **which is deleted at the sunset**. A redirect to the managed-signers guide will exist, so it won't 404 — but it would have advertised a retired product and dropped users somewhere unrelated. Repointed to `/docs/integrate-managed-signers`.

It also read *"Connect Farcaster accounts **for free** using…"*. That was true of SIWN specifically — Neynar sponsored signer registration — but is **not** true of managed signers, where the developer sponsors and pays compute units. Swapping only the product name would have preserved a pricing claim that no longer holds, so the claim is dropped rather than repointed.

## Not in scope

`wownar-react-sdk`, `wownar-react-native` and `fc2x` also demo SIWN and have the same problem. Left alone here — worth a follow-up.

## Verification

`tsc --noEmit` passes (exit 0). `yarn lint` could **not** be run: it's broken repo-wide independently of this change — `next lint` was removed in Next 16 (this app is on `next@^16.1.6`), and running `eslint` directly fails because the repo ships a legacy `.eslintrc.json` while `eslint@9` requires flat config, with `eslint-config-next` pinned at `^15`. Flagging rather than working around it.

`next build` not run — the app needs `NEYNAR_API_KEY` and other env vars unavailable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
